### PR TITLE
fix: 대여소 상세 페이지 진입 불가 문제 수정

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -23,16 +23,16 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
 			<>
 				<div className="min-h-screen bg-gray-100">
 					<div className="max-w-screen-sm mx-auto">
-						<OverlayProvider>
-							<NuqsAdapter>
-								<GoogleMapWrapper>
+						<GoogleMapWrapper>
+							<OverlayProvider>
+								<NuqsAdapter>
 									<StationMap />
 									<Outlet />
 									<MapController />
 									<BottomNavigation />
-								</GoogleMapWrapper>
-							</NuqsAdapter>
-						</OverlayProvider>
+								</NuqsAdapter>
+							</OverlayProvider>
+						</GoogleMapWrapper>
 					</div>
 				</div>
 				{getOperation() === "local" ? (


### PR DESCRIPTION
## 🛠️ 변경 사항
- fix: 대여소 상세 페이지 진입 불가 문제 수정
    - OverlayProvider가 APIProvider 바깥에 있어 Drawer 내부 NearbyStations의 useMap() 호출이 throw → Drawer 본문/footer 렌더 실패 → 상세 페이지 이동 불가
    - GoogleMapWrapper를 OverlayProvider 바깥으로 이동하여 해결

## 📸 스크린샷 (선택)
- 


close #125